### PR TITLE
fix: retry when no network

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-electron",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-electron",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "electron-config": "^1.0.0",


### PR DESCRIPTION
## Summary

When there's some socket error (e.g. lost connection), the socket will try to re-connect every X seconds, until the connection is established again.

Issue: #2 